### PR TITLE
security: fix CSRF/race condition OAuth, cookie Secure, cookie parsing, Gemini key header, ServingUnitType mismatch, logout cache clear

### DIFF
--- a/apps/dashboard/src/dto/food.ts
+++ b/apps/dashboard/src/dto/food.ts
@@ -1,6 +1,6 @@
 export enum ServingUnitType {
-  Weight = "Weight",
-  Volume = "Volume",
+  Weight = "weight",
+  Volume = "volume",
 }
 
 export type GetFoodsResponse = {

--- a/apps/dashboard/src/features/user-menu/components/user-menu.tsx
+++ b/apps/dashboard/src/features/user-menu/components/user-menu.tsx
@@ -1,6 +1,7 @@
 import { apiFetch } from "@/utils/api-fetch";
 import {
   QueryErrorResetBoundary,
+  useQueryClient,
   useSuspenseQuery,
 } from "@tanstack/react-query";
 import { Link, useNavigate } from "@tanstack/react-router";
@@ -11,25 +12,25 @@ import { getMe } from "../queries";
 
 const Component = () => {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { data } = useSuspenseQuery({
     queryKey: ["me"],
     queryFn: getMe,
     retry: false,
   });
 
+  const handleLogout = async () => {
+    await apiFetch("/auth/logout");
+    queryClient.clear();
+    navigate({ to: "/login" });
+  };
+
   return (
     <div>
       HOLA
       {data.name}
       <img src={data.picture} />
-      <Button
-        onClick={async () => {
-          await apiFetch("/auth/logout");
-          navigate({ to: "/", reloadDocument: true });
-        }}
-      >
-        Logout
-      </Button>
+      <Button onClick={handleLogout}>Logout</Button>
     </div>
   );
 };

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -7,6 +7,9 @@ resolver = "3"
 [dependencies]
 anyhow = "1.0.98"
 axum = "0.8.1"
+axum-extra = { version = "0.10", features = ["cookie"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 bigdecimal = { version = "0.4.8", features = ["serde"] }
 chrono = { version = "0.4.41", features = ["serde"] }
 dotenv = "0.15.0"

--- a/apps/server/src/connectors/gemini.rs
+++ b/apps/server/src/connectors/gemini.rs
@@ -17,42 +17,33 @@ impl GeminiClient {
     }
 
     pub async fn generate_content(&self, prompt: &str) -> Result<String> {
-        let url = format!(
-            "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key={}",
-            self.api_key
-        );
+        let url = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent";
 
         let body = serde_json::json!({
-            "contents": [
-                {
-                    "parts": [
-                        { "text": prompt }
-                    ]
-                }
-            ]
+            "contents": [{ "parts": [{ "text": prompt }] }]
         });
 
         let resp = self
             .client
-            .post(&url)
+            .post(url)
+            .header("x-goog-api-key", &self.api_key)
             .json(&body)
             .send()
             .await
-            .context("Failed to send request to Gemini")?; // convierte reqwest::Error en anyhow::Error con contexto
+            .context("failed to send request to Gemini")?;
 
         let json: GeminiResponse = resp
             .json()
             .await
-            .context("Failed to deserialize Gemini response")?;
+            .context("failed to deserialize Gemini response")?;
 
-        let Some(text) = json
-            .contents
-            .get(0)
-            .and_then(|c| c.parts.get(0))
-            .and_then(|p| p.text.clone())
-        else {
-            anyhow::bail!("No text content returned from Gemini");
-        };
+        let text = json
+            .candidates
+            .into_iter()
+            .next()
+            .and_then(|c| c.content.parts.into_iter().next())
+            .and_then(|p| p.text)
+            .ok_or_else(|| anyhow::anyhow!("no text content returned from Gemini"))?;
 
         Ok(text)
     }
@@ -60,7 +51,12 @@ impl GeminiClient {
 
 #[derive(Debug, Deserialize)]
 struct GeminiResponse {
-    contents: Vec<GeminiContent>,
+    candidates: Vec<GeminiCandidate>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GeminiCandidate {
+    content: GeminiContent,
 }
 
 #[derive(Debug, Deserialize)]

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -28,7 +28,14 @@ mod shared;
 
 #[tokio::main]
 async fn main() {
-    dotenv::from_path("apps/server/.env").ok();
+    dotenv::from_path(concat!(env!("CARGO_MANIFEST_DIR"), "/.env")).ok();
+
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    let cors_origin = std::env::var("CORS_ORIGIN")
+        .unwrap_or_else(|_| "http://localhost:3000".to_string());
 
     let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set");
     let db = Database::new(&database_url)
@@ -48,9 +55,9 @@ async fn main() {
         .layer(
             ServiceBuilder::new().layer(Extension(shared_db)).layer(
                 CorsLayer::new()
-                    .allow_methods([Method::GET, Method::POST, Method::PATCH])
+                    .allow_methods([Method::GET, Method::POST, Method::PATCH, Method::DELETE])
                     .allow_headers([ACCEPT, AUTHORIZATION, CONTENT_TYPE])
-                    .allow_origin("http://localhost:3000".parse::<HeaderValue>().unwrap())
+                    .allow_origin(cors_origin.parse::<HeaderValue>().expect("invalid CORS_ORIGIN"))
                     .allow_credentials(true),
             ),
         )
@@ -58,8 +65,8 @@ async fn main() {
 
     let listener = tokio::net::TcpListener::bind("0.0.0.0:8080").await.unwrap();
 
-    println!("SERVER RUNNING ON http://localhost:8080");
-    println!("VIEW DOCS ON http://localhost:8080/docs");
+    tracing::info!("server running on http://localhost:8080");
+    tracing::info!("docs available at http://localhost:8080/docs");
 
     axum::serve(listener, app).await.unwrap();
 }

--- a/apps/server/src/modules/auth/google.rs
+++ b/apps/server/src/modules/auth/google.rs
@@ -11,7 +11,10 @@ use oauth2::{
 };
 use reqwest::header::SET_COOKIE;
 use serde::{Deserialize, Serialize};
-use std::sync::{Arc, Mutex};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
 
 use crate::{
     connectors::{
@@ -26,7 +29,8 @@ use super::routes::GoogleOAuthClient;
 #[derive(Clone)]
 pub struct OAuthState {
     pub client: GoogleOAuthClient,
-    pub verifier: Arc<Mutex<Option<(PkceCodeVerifier, CsrfToken)>>>,
+    /// Keyed by the CSRF state secret. One entry per in-flight OAuth flow.
+    pub pending: Arc<Mutex<HashMap<String, PkceCodeVerifier>>>,
 }
 
 pub fn google_routes(state: OAuthState) -> Router {
@@ -49,7 +53,11 @@ async fn login_with_google(State(state): State<Arc<OAuthState>>) -> impl IntoRes
         .set_pkce_challenge(pkce_challenge)
         .url();
 
-    *state.verifier.lock().unwrap() = Some((pkce_verifier, csrf_token));
+    state
+        .pending
+        .lock()
+        .unwrap()
+        .insert(csrf_token.secret().clone(), pkce_verifier);
 
     Redirect::temporary(auth_url.as_ref())
 }
@@ -59,7 +67,7 @@ async fn logout() -> impl IntoResponse {
     let mut headers = HeaderMap::new();
     headers.insert(
         SET_COOKIE,
-        "token=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0"
+        "token=; Path=/; HttpOnly; SameSite=Strict; Secure; Max-Age=0"
             .parse()
             .unwrap(),
     );
@@ -84,102 +92,121 @@ pub struct GoogleUserInfo {
     pub sub: String,
 }
 
+type CallbackError = (StatusCode, &'static str);
+
 async fn google_callback(
     Extension(db): Extension<Arc<Database>>,
     State(state): State<Arc<OAuthState>>,
     Query(query): Query<AuthRequest>,
-) -> Result<impl IntoResponse, (StatusCode, &'static str)> {
-    let code = AuthorizationCode::new(query.code);
-
-    let (pkce_verifier, _) = state.verifier.lock().unwrap().take().unwrap();
+) -> Result<impl IntoResponse, CallbackError> {
+    // CSRF + race condition: look up verifier by the received state secret.
+    // If it's not in the map, the state was forged or already consumed.
+    let pkce_verifier = state
+        .pending
+        .lock()
+        .unwrap()
+        .remove(&query.state)
+        .ok_or((StatusCode::BAD_REQUEST, "invalid or expired oauth state"))?;
 
     let http_client = reqwest::ClientBuilder::new()
-        // Following redirects opens the client up to SSRF vulnerabilities.
         .redirect(reqwest::redirect::Policy::none())
         .build()
-        .expect("Client should build");
+        .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "failed to build http client"))?;
 
     let token_result = state
         .client
-        .exchange_code(code)
+        .exchange_code(AuthorizationCode::new(query.code))
         .set_pkce_verifier(pkce_verifier)
         .request_async(&http_client)
-        .await;
+        .await
+        .map_err(|e| {
+            tracing::error!(?e, "token exchange failed");
+            (StatusCode::INTERNAL_SERVER_ERROR, "login failed")
+        })?;
 
-    match token_result {
-        Ok(token) => {
-            println!("Access token: {:?}", token.access_token().secret());
-            let token = token.access_token().secret();
+    let access_token = token_result.access_token().secret();
 
-            let user_info = http_client
-                .get("https://www.googleapis.com/oauth2/v3/userinfo")
-                .bearer_auth(token)
-                .send()
-                .await
-                .unwrap()
-                .json::<GoogleUserInfo>()
-                .await
-                .unwrap();
+    let user_info = http_client
+        .get("https://www.googleapis.com/oauth2/v3/userinfo")
+        .bearer_auth(access_token)
+        .send()
+        .await
+        .map_err(|e| {
+            tracing::error!(?e, "failed to fetch user info");
+            (StatusCode::INTERNAL_SERVER_ERROR, "login failed")
+        })?
+        .json::<GoogleUserInfo>()
+        .await
+        .map_err(|e| {
+            tracing::error!(?e, "failed to deserialize user info");
+            (StatusCode::INTERNAL_SERVER_ERROR, "login failed")
+        })?;
 
-            println!("USER INFO {:?}", user_info);
+    let (user_id, email) = if let Some(existing_user) = db
+        .user
+        .get_by_email(user_info.email.as_str())
+        .await
+        .map_err(|e| {
+            tracing::error!(?e, "db error looking up user");
+            (StatusCode::INTERNAL_SERVER_ERROR, "login failed")
+        })? {
+        let needs_update = existing_user.name.as_deref() != Some(&user_info.name)
+            || existing_user.given_name.as_deref() != Some(&user_info.given_name)
+            || existing_user.family_name.as_deref() != Some(&user_info.family_name)
+            || existing_user.picture.as_deref() != Some(&user_info.picture);
 
-            let (user_id, email) = if let Some(existing_user) = db
-                .user
-                .get_by_email(user_info.email.as_str())
-                .await
-                .unwrap()
-            {
-                let needs_update = existing_user.name.as_deref() != Some(&user_info.name)
-                    || existing_user.given_name.as_deref() != Some(&user_info.given_name)
-                    || existing_user.family_name.as_deref() != Some(&user_info.family_name)
-                    || existing_user.picture.as_deref() != Some(&user_info.picture);
-
-                if needs_update {
-                    let updated_user = UpdateUser {
-                        name: Some(user_info.name.clone()),
-                        given_name: Some(user_info.given_name.clone()),
-                        family_name: Some(user_info.family_name.clone()),
-                        picture: Some(user_info.picture.clone()),
-                    };
-                    db.user
-                        .update(existing_user.id, &updated_user)
-                        .await
-                        .unwrap();
-                }
-                (existing_user.id, existing_user.email)
-            } else {
-                let new_user = NewUser {
-                    email: user_info.email.clone(),
-                    name: Some(user_info.name.clone()),
-                    given_name: Some(user_info.given_name.clone()),
-                    family_name: Some(user_info.family_name.clone()),
-                    picture: Some(user_info.picture.clone()),
-                };
-                let user = db.user.create(&new_user).await.unwrap();
-                (user.id, user.email)
+        if needs_update {
+            let updated_user = UpdateUser {
+                name: Some(user_info.name.clone()),
+                given_name: Some(user_info.given_name.clone()),
+                family_name: Some(user_info.family_name.clone()),
+                picture: Some(user_info.picture.clone()),
             };
-
-            let jwt = create_jwt_for_user(user_id, email).unwrap();
-
-            let redirect_url = "http://localhost:3000/";
-            let cookie = format!(
-                "token={}; Path=/; HttpOnly; SameSite=Lax; Max-Age={}",
-                jwt,
-                60 * 60 * 24 * 7
-            );
-
-            let mut headers = HeaderMap::new();
-            headers.insert(SET_COOKIE, cookie.parse().unwrap());
-
-            let response = Redirect::to(redirect_url).into_response();
-            let (mut parts, body) = response.into_parts();
-            parts.headers.extend(headers);
-
-            Ok(Response::from_parts(parts, body))
+            db.user
+                .update(existing_user.id, &updated_user)
+                .await
+                .map_err(|e| {
+                    tracing::error!(?e, "db error updating user");
+                    (StatusCode::INTERNAL_SERVER_ERROR, "login failed")
+                })?;
         }
-        Err(err) => {
-            eprintln!("Token exchange error: {:?}", err);
-            Err((StatusCode::INTERNAL_SERVER_ERROR, "Login failed"))
-        }
-    }
+        (existing_user.id, existing_user.email)
+    } else {
+        let new_user = NewUser {
+            email: user_info.email.clone(),
+            name: Some(user_info.name.clone()),
+            given_name: Some(user_info.given_name.clone()),
+            family_name: Some(user_info.family_name.clone()),
+            picture: Some(user_info.picture.clone()),
+        };
+        let user = db.user.create(&new_user).await.map_err(|e| {
+            tracing::error!(?e, "db error creating user");
+            (StatusCode::INTERNAL_SERVER_ERROR, "login failed")
+        })?;
+        (user.id, user.email)
+    };
+
+    let jwt = create_jwt_for_user(user_id, email).map_err(|e| {
+        tracing::error!(?e, "failed to create jwt");
+        (StatusCode::INTERNAL_SERVER_ERROR, "login failed")
+    })?;
+
+    let redirect_url = std::env::var("FRONTEND_URL").unwrap_or_else(|_| "http://localhost:3000/".to_string());
+    let cookie = format!(
+        "token={}; Path=/; HttpOnly; SameSite=Strict; Secure; Max-Age={}",
+        jwt,
+        60 * 60 * 24 * 7
+    );
+
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        SET_COOKIE,
+        cookie.parse().map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "login failed"))?,
+    );
+
+    let response = Redirect::to(&redirect_url).into_response();
+    let (mut parts, body) = response.into_parts();
+    parts.headers.extend(headers);
+
+    Ok(Response::from_parts(parts, body))
 }

--- a/apps/server/src/modules/auth/middleware.rs
+++ b/apps/server/src/modules/auth/middleware.rs
@@ -1,9 +1,10 @@
 use axum::{
     extract::Request,
-    http::{self, StatusCode},
+    http::StatusCode,
     middleware::Next,
     response::Response,
 };
+use axum_extra::extract::CookieJar;
 
 use super::jwt::Claims;
 
@@ -13,46 +14,22 @@ pub struct CurrentUser {
     pub email: String,
 }
 
-pub async fn auth(mut req: Request, next: Next) -> Result<Response, StatusCode> {
-    println!("AUTH MIDDLEWRAE INIT");
-    let token_cookie = req
-        .headers()
-        .get(http::header::COOKIE)
-        .and_then(|header| header.to_str().ok())
-        .and_then(|cookie_header| {
-            cookie_header.split(';').find_map(|cookie| {
-                let mut parts = cookie.trim().splitn(2, '=');
-                match (parts.next(), parts.next()) {
-                    (Some("token"), Some(value)) => Some(value),
-                    _ => None,
-                }
-            })
-        });
+pub async fn auth(
+    jar: CookieJar,
+    mut req: Request,
+    next: Next,
+) -> Result<Response, StatusCode> {
+    let token = jar
+        .get("token")
+        .map(|c| c.value().to_string())
+        .ok_or(StatusCode::UNAUTHORIZED)?;
 
-    println!("COOKIE {:?}", token_cookie);
+    let token_data = Claims::decode_jwt(&token).map_err(|_| StatusCode::UNAUTHORIZED)?;
 
-    let auth_token = if let Some(token) = token_cookie {
-        token
-    } else {
-        return Err(StatusCode::UNAUTHORIZED);
-    };
+    req.extensions_mut().insert(CurrentUser {
+        id: token_data.claims.user_id,
+        email: token_data.claims.email,
+    });
 
-    if let Some(current_user) = authorize_current_user(auth_token).await {
-        // insert the current user into a request extension so the handler can
-        // extract it
-        req.extensions_mut().insert(current_user);
-        Ok(next.run(req).await)
-    } else {
-        Err(StatusCode::UNAUTHORIZED)
-    }
-}
-
-async fn authorize_current_user(auth_token: &str) -> Option<CurrentUser> {
-    let token_data = Claims::decode_jwt(auth_token).ok()?;
-    let claims = token_data.claims;
-
-    Some(CurrentUser {
-        id: claims.user_id,
-        email: claims.email,
-    })
+    Ok(next.run(req).await)
 }

--- a/apps/server/src/modules/auth/routes.rs
+++ b/apps/server/src/modules/auth/routes.rs
@@ -1,4 +1,7 @@
-use std::sync::{Arc, Mutex};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
 
 use super::google::{OAuthState, google_routes};
 use axum::Router;
@@ -33,8 +36,9 @@ pub fn auth_routes() -> Router {
     let google_token_url = TokenUrl::new("https://www.googleapis.com/oauth2/v3/token".to_string())
         .expect("Invalid token endpoint URL");
 
-    let redirect_url = RedirectUrl::new("http://localhost:8080/auth/google/callback".to_string())
-        .expect("Invalid redirect URL");
+    let redirect_url =
+        RedirectUrl::new("http://localhost:8080/auth/google/callback".to_string())
+            .expect("Invalid redirect URL");
 
     let client = BasicClient::new(google_client_id)
         .set_client_secret(google_client_secret)
@@ -44,6 +48,6 @@ pub fn auth_routes() -> Router {
 
     google_routes(OAuthState {
         client,
-        verifier: Arc::new(Mutex::new(None)),
+        pending: Arc::new(Mutex::new(HashMap::new())),
     })
 }


### PR DESCRIPTION
- Closes #3 CSRF validado por lookup en HashMap (state secret como key)
- Closes #4 reemplaza Mutex<Option> por HashMap multiusuario
- Closes #5 elimina .unwrap() del callback OAuth, reemplaza con map_err
- Closes #6 elimina println! de tokens sensibles; usa tracing
- Closes #7 añade Secure y SameSite=Strict a la cookie de sesión
- Closes #8 mueve API key de Gemini de query string a header x-goog-api-key
- Closes #10 corrige GeminiResponse shape (candidates en vez de contents)
- Closes #12 reemplaza parseo manual de cookies por axum_extra CookieJar
- Closes #13 dotenv carga desde CARGO_MANIFEST_DIR en vez de CWD relativo
- Closes #15 tracing-subscriber con EnvFilter; sustituye println! por tracing
- Closes #22 CORS_ORIGIN desde env; añade DELETE a métodos CORS
- Closes #11 fix ServingUnitType lowercase para coincidir con backend
- Closes #19 queryClient.clear() en logout