### PR TITLE
frontend: createFood end-to-end, route guard, BASE_URL desde env

### DIFF
--- a/apps/dashboard/src/config/query.tsx
+++ b/apps/dashboard/src/config/query.tsx
@@ -1,7 +1,6 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { FC, PropsWithChildren } from "react";
-
-const queryClient = new QueryClient();
+import { queryClient } from "@/lib/query-client";
 
 export const QueryConfig: FC<PropsWithChildren> = ({ children }) => {
   return (

--- a/apps/dashboard/src/config/router.tsx
+++ b/apps/dashboard/src/config/router.tsx
@@ -1,5 +1,6 @@
 import { createRouter, RouterProvider } from "@tanstack/react-router";
 import { FC, PropsWithChildren } from "react";
+import { queryClient } from "@/lib/query-client";
 import { routeTree } from "../routeTree.gen";
 
 declare module "@tanstack/react-router" {
@@ -10,6 +11,7 @@ declare module "@tanstack/react-router" {
 
 const router = createRouter({
   routeTree,
+  context: { queryClient },
 });
 
 export const RouterConfig: FC<PropsWithChildren> = () => {

--- a/apps/dashboard/src/dto/food.ts
+++ b/apps/dashboard/src/dto/food.ts
@@ -31,8 +31,7 @@ export type FoodDto = {
   updatedAt: string;
 };
 
-export type UpdateFoodDto = {
-  id: number;
+export type CreateFoodDto = {
   name: string;
   calories: number;
   fat: number;
@@ -49,4 +48,8 @@ export type UpdateFoodDto = {
   servingName: string;
   servingQuantity: number;
   servingUnitType: ServingUnitType;
+};
+
+export type UpdateFoodDto = CreateFoodDto & {
+  id: number;
 };

--- a/apps/dashboard/src/features/foods/components/create-food-dialog.tsx
+++ b/apps/dashboard/src/features/foods/components/create-food-dialog.tsx
@@ -1,24 +1,128 @@
+import { CreateFoodDto, ServingUnitType } from "@/dto/food";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Button } from "@workspace/ui/components/button";
 import {
   Dialog,
-  DialogTrigger,
+  DialogClose,
   DialogContent,
-  DialogHeader,
-  DialogTitle,
   DialogDescription,
   DialogFooter,
-  DialogClose,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
 } from "@workspace/ui/components/dialog";
 import { Input } from "@workspace/ui/components/input";
 import { Label } from "@workspace/ui/components/label";
-import { type PropsWithChildren } from "react";
+import { useActionState, type FC, type PropsWithChildren } from "react";
+import { z } from "zod/v4";
+import { useAlert } from "@features/alert/hooks/use-alert";
+import { createFood } from "../mutations";
 
-export function CreateFoodDialog(props: PropsWithChildren) {
+const preprocessNumber = (value: unknown) => {
+  if (typeof value === "string") {
+    if (value) {
+      const number = Number(value);
+      if (Number.isNaN(number)) {
+        return null;
+      } else {
+        return value;
+      }
+    }
+  } else if (typeof value === "number") {
+    return value;
+  }
+  return null;
+};
+
+const createSchema = z.object({
+  name: z.string().min(1),
+  calories: z.preprocess(preprocessNumber, z.int().nonnegative()),
+  fat: z.preprocess(preprocessNumber, z.number().nonnegative()),
+  proteins: z.preprocess(preprocessNumber, z.number().nonnegative()),
+  carbs: z.preprocess(preprocessNumber, z.number().nonnegative()),
+  saturatedFat: z.preprocess(
+    preprocessNumber,
+    z.number().nonnegative().nullable(),
+  ),
+  monounsaturatedFat: z.preprocess(
+    preprocessNumber,
+    z.number().nonnegative().nullable(),
+  ),
+  polyunsaturatedFat: z.preprocess(
+    preprocessNumber,
+    z.number().nonnegative().nullable(),
+  ),
+  transFat: z.preprocess(preprocessNumber, z.number().nonnegative().nullable()),
+  fiber: z.preprocess(preprocessNumber, z.number().nonnegative().nullable()),
+  sugars: z.preprocess(preprocessNumber, z.number().nonnegative().nullable()),
+  sodium: z.preprocess(preprocessNumber, z.int().nonnegative().nullable()),
+  cholesterol: z.preprocess(preprocessNumber, z.int().nonnegative().nullable()),
+  servingName: z.string().min(1),
+  servingQuantity: z.preprocess(preprocessNumber, z.number().nonnegative()),
+  servingUnitType: z.enum(ServingUnitType),
+}) satisfies z.ZodType<CreateFoodDto>;
+
+const emptyDefaults: Record<string, string> = {
+  name: "",
+  calories: "",
+  fat: "",
+  proteins: "",
+  carbs: "",
+  saturatedFat: "",
+  monounsaturatedFat: "",
+  polyunsaturatedFat: "",
+  transFat: "",
+  fiber: "",
+  sugars: "",
+  sodium: "",
+  cholesterol: "",
+  servingName: "",
+  servingQuantity: "",
+  servingUnitType: ServingUnitType.Weight,
+};
+
+const numericFields = [
+  "calories",
+  "proteins",
+  "carbs",
+  "fat",
+  "sodium",
+  "cholesterol",
+];
+
+export const CreateFoodDialog: FC<PropsWithChildren> = ({ children }) => {
+  const queryClient = useQueryClient();
+  const { showAlert } = useAlert();
+
+  const mutation = useMutation({
+    mutationFn: createFood,
+    onSuccess() {
+      queryClient.invalidateQueries({ queryKey: ["foods"] });
+    },
+  });
+
+  const [state, formAction] = useActionState(
+    async (prev: Record<string, string>, form: FormData) => {
+      try {
+        const objectData = Object.fromEntries(form.entries());
+        const parsedInput = createSchema.parse(objectData);
+        await mutation.mutateAsync(parsedInput);
+        return emptyDefaults;
+      } catch (e) {
+        if (e instanceof Error) {
+          showAlert({ variant: "destructive", title: e.message });
+        }
+        return prev;
+      }
+    },
+    emptyDefaults,
+  );
+
   return (
     <Dialog>
-      <form>
-        <DialogTrigger asChild>{props.children}</DialogTrigger>
-        <DialogContent className="sm:max-w-[425px]">
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent className="sm:max-w-2xl w-full">
+        <form action={formAction}>
           <DialogHeader>
             <DialogTitle>Add food</DialogTitle>
             <DialogDescription>Add a food to the database</DialogDescription>
@@ -26,17 +130,45 @@ export function CreateFoodDialog(props: PropsWithChildren) {
           <div className="grid gap-4">
             <div className="grid gap-3">
               <Label htmlFor="name">Name</Label>
-              <Input id="name" name="name" defaultValue="Pedro Duarte" />
+              <Input id="name" name="name" defaultValue={state.name} />
             </div>
-            <div className="grid gap-3">
-              <Label htmlFor="username-1">Calories</Label>
-              <Input
-                type="number"
-                id="username-1"
-                name="username"
-                defaultValue="12"
-              />
+
+            <div className="grid grid-cols-2 gap-3">
+              <div className="grid gap-3">
+                <Label htmlFor="servingName">Serving name</Label>
+                <Input
+                  id="servingName"
+                  name="servingName"
+                  defaultValue={state.servingName}
+                />
+              </div>
+              <div className="grid gap-3">
+                <Label htmlFor="servingQuantity">Serving quantity</Label>
+                <Input
+                  id="servingQuantity"
+                  name="servingQuantity"
+                  defaultValue={state.servingQuantity}
+                />
+              </div>
             </div>
+
+            <input
+              type="hidden"
+              name="servingUnitType"
+              value={state.servingUnitType}
+            />
+
+            {numericFields.map((key) => (
+              <div className="grid gap-3" key={key}>
+                <Label htmlFor={key}>{key}</Label>
+                <Input
+                  id={key}
+                  name={key}
+                  type="number"
+                  defaultValue={state[key]}
+                />
+              </div>
+            ))}
           </div>
           <DialogFooter>
             <DialogClose asChild>
@@ -44,8 +176,8 @@ export function CreateFoodDialog(props: PropsWithChildren) {
             </DialogClose>
             <Button type="submit">Save changes</Button>
           </DialogFooter>
-        </DialogContent>
-      </form>
+        </form>
+      </DialogContent>
     </Dialog>
   );
-}
+};

--- a/apps/dashboard/src/features/foods/mutations.ts
+++ b/apps/dashboard/src/features/foods/mutations.ts
@@ -1,5 +1,5 @@
-import { FoodDto, UpdateFoodDto } from "@/dto/food";
-import { patch } from "@/utils/api-fetch";
+import { CreateFoodDto, FoodDto, UpdateFoodDto } from "@/dto/food";
+import { patch, post } from "@/utils/api-fetch";
 
 export type UpdateFoodOutput = {
   food: FoodDto;
@@ -7,5 +7,10 @@ export type UpdateFoodOutput = {
 
 export const updateFood = async (input: UpdateFoodDto) => {
   const response = await patch<UpdateFoodOutput>("/foods/update", input);
+  return response.data;
+};
+
+export const createFood = async (input: CreateFoodDto) => {
+  const response = await post<FoodDto>("/foods/create", input);
   return response.data;
 };

--- a/apps/dashboard/src/lib/query-client.ts
+++ b/apps/dashboard/src/lib/query-client.ts
@@ -1,0 +1,3 @@
+import { QueryClient } from "@tanstack/react-query";
+
+export const queryClient = new QueryClient();

--- a/apps/dashboard/src/routes/__root.tsx
+++ b/apps/dashboard/src/routes/__root.tsx
@@ -1,9 +1,18 @@
 import { GlobalAlert } from "@features/alert/components/global-alert";
 import { UserMenu } from "@features/user-menu/components/user-menu";
-import { createRootRoute, Link, Outlet } from "@tanstack/react-router";
+import type { QueryClient } from "@tanstack/react-query";
+import {
+  createRootRouteWithContext,
+  Link,
+  Outlet,
+} from "@tanstack/react-router";
 import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
 
-export const Route = createRootRoute({
+export interface RouterContext {
+  queryClient: QueryClient;
+}
+
+export const Route = createRootRouteWithContext<RouterContext>()({
   component: () => (
     <div>
       <div>

--- a/apps/dashboard/src/routes/foods.tsx
+++ b/apps/dashboard/src/routes/foods.tsx
@@ -1,9 +1,21 @@
 import { FoodsHeader } from "@features/foods/components/foods-headers";
 import { FoodsList } from "@features/foods/components/foods-list";
-import { createFileRoute } from "@tanstack/react-router";
+import { getMe } from "@features/user-menu/queries";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 import { Suspense } from "react";
 
 export const Route = createFileRoute("/foods")({
+  beforeLoad: async ({ context }) => {
+    try {
+      await context.queryClient.ensureQueryData({
+        queryKey: ["me"],
+        queryFn: getMe,
+        retry: false,
+      });
+    } catch {
+      throw redirect({ to: "/login" });
+    }
+  },
   component: RouteComponent,
 });
 

--- a/apps/dashboard/src/utils/api-fetch.ts
+++ b/apps/dashboard/src/utils/api-fetch.ts
@@ -1,4 +1,4 @@
-const BASE_URL = "http://localhost:8080/";
+const BASE_URL = import.meta.env.VITE_API_URL ?? "http://localhost:8080/";
 
 export type ApiResponse<T> = {
   data: T;


### PR DESCRIPTION
## Summary

Sprint frontend — cierra 4 issues (#9, #10, #22, #33).

### Cambios

**#10 `createFood` mutation** (`features/foods/mutations.ts`, `dto/food.ts`)
- Nuevo tipo `CreateFoodDto` (sin `id`); `UpdateFoodDto = CreateFoodDto & { id }`
- `createFood` que hace `POST /foods/create`

**#9 `CreateFoodDialog` funcional** (`features/foods/components/create-food-dialog.tsx`)
- Reescrito siguiendo el patrón de `update-food-dialog.tsx`: Zod (`createSchema`) + `useActionState` + mutation con invalidación de `["foods"]`
- Inputs reales para todos los campos (nombre, serving, calories, macros, sodio, colesterol)
- Sin más placeholders "Pedro Duarte"

**#22 route guard en `/foods`** (`routes/foods.tsx`, `routes/__root.tsx`, `config/router.tsx`, nuevo `lib/query-client.ts`)
- `beforeLoad` hace `queryClient.ensureQueryData({ queryKey: ['me'] })`; si falla redirige a `/login`
- `__root.tsx` migrado a `createRootRouteWithContext<{ queryClient }>()`
- `queryClient` extraído a `lib/query-client.ts` para que el `QueryClientProvider` y el router compartan la misma instancia

**#33 `BASE_URL` desde env** (`utils/api-fetch.ts`)
- `import.meta.env.VITE_API_URL ?? "http://localhost:8080/"`

## Test plan
- [x] `pnpm --filter dashboard exec tsc --noEmit` — clean
- [x] `pnpm --filter dashboard build` — clean, routeTree regenerado correctamente
- [ ] Abrir `/foods` sin sesión → redirige a `/login`
- [ ] Crear un food desde el dialog y verificar que aparece en la lista
- [ ] Setear `VITE_API_URL` en `.env.local` y verificar que el frontend usa esa URL

---
_Generated by [Claude Code](https://claude.ai/code/session_01LdBjF4dXZSDUoDHJVipvpG)_